### PR TITLE
fixed OutOfMemoryError in RxScala

### DIFF
--- a/src/main/scala/org/zalando/benchmarks/ComputationFollowedByAsyncPublishing.scala
+++ b/src/main/scala/org/zalando/benchmarks/ComputationFollowedByAsyncPublishing.scala
@@ -40,8 +40,7 @@ class ComputationFollowedByAsyncPublishing {
   @Benchmark def bmParallelFutures(): Unit =  futures benchmark  1          // <=  44 threads ("Live peak" in JVisualVM)
   @Benchmark def bmBlocking():        Unit = blocking benchmark 64          // <= 549 threads ("Live peak" in JVisualVM)
   @Benchmark def bmStreams():         Unit =  streams benchmark  1          // <=  52 threads ("Live peak" in JVisualVM)
-
-//@Benchmark def bmRxScala():         Unit =       rx benchmark             // blows up with OutOfMemoryError :(
+  @Benchmark def bmRxScala():         Unit =        rx benchmark 1          // <= 50 threads
 
   @TearDown def tearDown(): Unit = system.terminate()
 }


### PR DESCRIPTION
Since I am currently working with RxScala intensively I thought I could try to fix your example with RxScala ;).
1. subscribeOn usage was wrong: subscribeOn does not distribute the calculations over multiple threads. It just hangs out the observable into another thread so the whole stream just runs in another single thread.
2. toBlocking must be used to make the subscriber (foreach) to block. Otherwise foreach will not block and benchmark() just returns immediately.

P.S. on my Mac RxScala outperforms all others ;). But I did only 2 iterations instead of 20 ;). But to be more precise all examples have to be refactored a little bit to put initialization code out of benchmark() methods. e.g. execution context init and shutdown, Akka graph init, etc.